### PR TITLE
typo-fix

### DIFF
--- a/web-frontend/src/ProjectInfo/ProjectInfo.jsx
+++ b/web-frontend/src/ProjectInfo/ProjectInfo.jsx
@@ -166,7 +166,7 @@ const ProjectInfo = () => {
                             please use the following citation:
                         </div>
                         Alden Blatter, Hortense Gallois, Samantha Salvi Cruz,
-                        Yael Bensoussan, Bride2AI Voice Consortium, Maria
+                        Yael Bensoussan, Bridge2AI Voice Consortium, Maria
                         Powell, Jean-Christophe Bélisle-Pipon. (2025). “Global
                         Voice Datasets Repository Map.” Voice Data Governance.
                         Retrieved Month Day, Year, from{" "}


### PR DESCRIPTION
This pull request includes a correction to a typographical error in the `ProjectInfo` component of the `web-frontend` project. The change corrects the name "Bride2AI" to "Bridge2AI" in the citation text.

Changes in `ProjectInfo` component:

* Corrected "Bride2AI" to "Bridge2AI" in the citation text. (`web-frontend/src/ProjectInfo/ProjectInfo.jsx`)